### PR TITLE
FVTT v14 compatibility

### DIFF
--- a/hookmacro.js
+++ b/hookmacro.js
@@ -178,7 +178,7 @@ class HookSettingsApplication extends FormApplication {
   }
 
   static get defaultOptions() {
-    return mergeObject(super.defaultOptions, {
+    return foundry.utils.mergeObject(super.defaultOptions, {
       id: 'macro-hooks-settings',
       classes: ['sheet'],
       template: 'modules/launchmacro/templates/settingsPopup.html',
@@ -228,7 +228,7 @@ class HookSettingsApplication extends FormApplication {
     let hook = html.find('#newEntry-Hook')[0]?.value || ''
     let macro = html.find('#newEntry-Macro')[0]?.value || ''
     let args = html.find('#newEntry-Args')[0]?.value || ''
-    let id = randomID()
+    let id = foundry.utils.randomID()
 
     let compiledTemplate = settingsEntry({
       hook,

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "title": "Hook Macros",
   "description": "Launch macros from hooks",
   "url": "https://github.com/ardittristan/HookMacros/tree/master",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "esmodules": [
     "hookmacro.js"
   ],

--- a/module.json
+++ b/module.json
@@ -23,6 +23,6 @@
   "id": "launchmacro",
   "compatibility": {
     "minimum": "13",
-    "verified": "13"
+    "verified": "14"
   }
 }


### PR DESCRIPTION
## Summary

Foundry VTT v14 removed the bare global helper functions `mergeObject` and `randomID`; they are now only exposed under the `foundry.utils` namespace. As a result, opening either of the module's settings menus (**Configure Settings → Hook Macros**, global and local) throws:

```
Uncaught (in promise) ReferenceError: mergeObject is not defined
    at get defaultOptions (hookmacro.js:181)
    at new Application (foundry.mjs) → new FormApplication → new HookSettingsApplication
```

and adding a new entry would similarly throw on `randomID` (`hookmacro.js:231`).

## Fix

Replace the two removed bare globals with their namespaced `foundry.utils.*` equivalents: `mergeObject(...)` → `foundry.utils.mergeObject(...)` in `HookSettingsApplication.defaultOptions` (`hookmacro.js:181`), and `randomID()` → `foundry.utils.randomID()` in `addEntry` (`hookmacro.js:231`).

These reference the identical functions and also exist on v13, so behavior is unchanged and the declared `minimum: "13"` still holds. `compatibility.verified` is bumped `13 → 14`.
